### PR TITLE
Windows compat fixes

### DIFF
--- a/bin/warbler-exec
+++ b/bin/warbler-exec
@@ -14,13 +14,28 @@ Zip::ZipFile.open(path_to_war) do |zipfile|
   end
 end
 
-Dir.chdir(File.join(destination, "WEB-INF"))
+workdir = File.join(destination, "WEB-INF") 
+Dir.chdir(workdir)
+
 ENV["CLASSPATH"] = Dir["#{Dir.pwd}/lib/*.jar"].join(File::PATH_SEPARATOR)
 ENV["GEM_PATH"] = "#{Dir.pwd}/gems"
 ENV["GEM_HOME"] = "#{Dir.pwd}/gems"
 
 begin 
-  Kernel.exec("java -Xmx512m -cp #{ENV["CLASSPATH"]} org.jruby.Main #{ARGV.join(" ")}")
+  # the unix way is the default way
+  cmd = "java -Xmx512m -cp $CLASSPATH org.jruby.Main #{ARGV.join(" ")}"
+  
+  # jruby makes testing the platform via RUBY_PLATFORM unreliable, so we resort to testing
+  # the path separator
+  if ";" == File::PATH_SEPARATOR
+    cmd = "java -Xmx512m -cp %CLASSPATH% org.jruby.Main #{ARGV.join(" ")}"
+    # work around http://jira.codehaus.org/browse/JRUBY-6994 which makes Kernel.exec forget about chdir
+    if defined?(JRUBY_VERSION) && JRUBY_VERSION < "1.7.1"
+      cmd = "cd #{workdir} #{cmd}"
+    end
+  end
+
+  Kernel.exec(cmd)
 rescue Errno::EACCES
   puts "warbler-exec: not executable: #{ARGV.first}"
   exit 126
@@ -30,6 +45,6 @@ rescue Errno::ENOENT
 rescue ArgumentError
   puts "warbler-exec: exec needs a command to run"
   exit 128
-end
+end 
 
 

--- a/bin/warbler-exec
+++ b/bin/warbler-exec
@@ -30,7 +30,7 @@ begin
     cmd = "java -Xmx512m -cp %CLASSPATH% org.jruby.Main #{ARGV.join(" ")}"
     # work around http://jira.codehaus.org/browse/JRUBY-6994 which makes Kernel.exec forget about chdir
     if defined?(JRUBY_VERSION) && JRUBY_VERSION < "1.7.1"
-      cmd = "cd #{workdir} #{cmd}"
+      cmd = "cd #{workdir} & #{cmd}"
     end
   end
 

--- a/bin/warbler-exec
+++ b/bin/warbler-exec
@@ -15,12 +15,12 @@ Zip::ZipFile.open(path_to_war) do |zipfile|
 end
 
 Dir.chdir(File.join(destination, "WEB-INF"))
-ENV["CLASSPATH"] = Dir["#{Dir.pwd}/lib/*.jar"].join(":")
+ENV["CLASSPATH"] = Dir["#{Dir.pwd}/lib/*.jar"].join(File::PATH_SEPARATOR)
 ENV["GEM_PATH"] = "#{Dir.pwd}/gems"
 ENV["GEM_HOME"] = "#{Dir.pwd}/gems"
 
-begin
-  Kernel.exec("java -Xmx512m -cp $CLASSPATH org.jruby.Main #{ARGV.join(" ")}")
+begin 
+  Kernel.exec("java -Xmx512m -cp #{ENV["CLASSPATH"]} org.jruby.Main #{ARGV.join(" ")}")
 rescue Errno::EACCES
   puts "warbler-exec: not executable: #{ARGV.first}"
   exit 126

--- a/bin/warbler-exec
+++ b/bin/warbler-exec
@@ -2,6 +2,7 @@
 
 require 'zip/zip'
 require 'tmpdir'
+require 'rbconfig'
 
 path_to_war = ARGV.shift 
 
@@ -25,9 +26,7 @@ begin
   # the unix way is the default way
   cmd = "java -Xmx512m -cp $CLASSPATH org.jruby.Main #{ARGV.join(" ")}"
   
-  # jruby makes testing the platform via RUBY_PLATFORM unreliable, so we resort to testing
-  # the path separator
-  if ";" == File::PATH_SEPARATOR
+  if /mswin/ =~ RbConfig::CONFIG["host_os"]
     cmd = "java -Xmx512m -cp %CLASSPATH% org.jruby.Main #{ARGV.join(" ")}"
     # work around http://jira.codehaus.org/browse/JRUBY-6994 which makes Kernel.exec forget about chdir
     if defined?(JRUBY_VERSION) && JRUBY_VERSION < "1.7.1"


### PR DESCRIPTION
The current version of warbler-exec does not run on windows due to two main issues:
- Variable substitution happens with %var% and not with $var
- The path separator is ";" not ":"

Then there's a minor issue with jruby < 1.7.1 and chdir: The spawned subshell on windows will not inherit the parents path, so the use of chdir in the script has no effect. The directory change must happen in the subshell.
